### PR TITLE
Blog taxonomy improvements

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -58,6 +58,8 @@ keyholder = "Geschlossen (Keyholder Only)"
 ifs_newest = "Neuste Images From Space"
 ifs_more = "Viele weitere Fotos findest du hier:"
 
+blog = "Blog"
+
 [extra]
 ifs_base_path = "https://www.mainframe.io/media/ifs-images"
 bs_color_map = [
@@ -110,3 +112,5 @@ keyholder = "Closed (Keyholder Only)"
 
 ifs_newest = "Newest Images From Space"
 ifs_more = "You can find more images here:"
+
+blog = "Blog"

--- a/content/blog/2011/2011-12-01-forumslader.md
+++ b/content/blog/2011/2011-12-01-forumslader.md
@@ -5,8 +5,8 @@ date = "2011-12-01T10:00:00"
 updated = "2024-03-24T23:42:00"
 
 [taxonomies]
-Serie = ["Projekt"]
-Typ = ["Hardware"]
+Typ = ["Projekt"]
+Serie = ["Hardware"]
 
 [extra]
 thumbnail = "/media/blog/2011/forumslader/forumslader.jpg"

--- a/content/blog/2011/2011-12-01-inventarsystem.md
+++ b/content/blog/2011/2011-12-01-inventarsystem.md
@@ -5,8 +5,8 @@ date = "2011-12-01T10:00:00"
 updated = "2024-03-24T23:42:00"
 
 [taxonomies]
-Serie = ["Projekt"]
-Typ = ["Software"]
+Typ = ["Projekt"]
+Serie = ["Software"]
 
 [extra]
 thumbnail = "/media/blog/2011/inventarsystem/inventarsystem.jpg"

--- a/content/blog/2011/2011-12-01-shopsystem.md
+++ b/content/blog/2011/2011-12-01-shopsystem.md
@@ -5,8 +5,8 @@ updated = "2024-03-24T23:42:00"
 authors = ["sre", "lhw"]
 
 [taxonomies]
-Serie = ["Projekt"]
-Typ = ["Software"]
+Typ = ["Projekt"]
+Serie = ["Software"]
 
 [extra]
 thumbnail = "/media/blog/2011/shopsystem/shopsystem.jpg"

--- a/content/blog/2012/2012-02-12-styroschneider.md
+++ b/content/blog/2012/2012-02-12-styroschneider.md
@@ -6,8 +6,8 @@ updated = "2024-03-24T23:42:00"
 authors = ["0xFF", "SebSetz"]
 
 [taxonomies]
-Serie = ["Projekt"]
-Typ = ["Hardware"]
+Typ = ["Projekt"]
+Serie = ["Hardware"]
 
 [extra]
 thumbnail = "/media/blog/2012/styroschneider/0000.jpg"

--- a/content/blog/2012/2012-05-07-spaceschalter.md
+++ b/content/blog/2012/2012-05-07-spaceschalter.md
@@ -6,8 +6,8 @@ updated = "2024-03-24T23:42:00"
 authors = ["Thorben"]
 
 [taxonomies]
-Serie = ["Projekt"]
-Typ = ["Infrastructure"]
+Typ = ["Projekt"]
+Serie = ["Infrastructure"]
 
 [extra]
 thumbnail = "/media/blog/2012/spaceschalter/spaceschalter.jpg"

--- a/content/blog/2012/2012-05-17-terminals.md
+++ b/content/blog/2012/2012-05-17-terminals.md
@@ -6,8 +6,8 @@ updated = "2024-03-24T23:42:00"
 authors = ["olt"]
 
 [taxonomies]
-Serie = ["Projekt"]
-Typ = ["Hardware"]
+Typ = ["Projekt"]
+Serie = ["Hardware"]
 
 [extra]
 thumbnail = "/media/blog/2012/terminals/thumbnail.jpg"

--- a/content/blog/2012/2012-05-22-arduino-comic.md
+++ b/content/blog/2012/2012-05-22-arduino-comic.md
@@ -5,8 +5,8 @@ updated = "2024-03-24T23:42:00"
 authors = ["thorben"]
 
 [taxonomies]
-Serie = ["Projekt"]
-Typ = ["Software"]
+Typ = ["Projekt"]
+Serie = ["Software"]
 
 [extra]
 thumbnail = "/media/blog/2012/arduino-comic/thumbnail.jpg"

--- a/content/blog/2012/2012-07-03-lauflicht.md
+++ b/content/blog/2012/2012-07-03-lauflicht.md
@@ -6,8 +6,8 @@ updated = "2024-03-24T23:42:00"
 authors = ["MarvinGS"]
 
 [taxonomies]
-Serie = ["Projekt"]
-Typ = ["Hardware"]
+Typ = ["Projekt"]
+Serie = ["Hardware"]
 
 [extra]
 thumbnail = "/media/blog/2012/lauflicht/img1.jpg"

--- a/content/blog/2012/2012-11-06-flying-games-logo.md
+++ b/content/blog/2012/2012-11-06-flying-games-logo.md
@@ -6,8 +6,8 @@ updated = "2024-03-24T23:42:00"
 authors = ["fermate"]
 
 [taxonomies]
-Serie = ["Projekt"]
-Typ = ["Hardware"]
+Typ = ["Projekt"]
+Serie = ["Hardware"]
 
 [extra]
 thumbnail = "/media/blog/2012/flying-games-logo/thumbnail.jpg"

--- a/content/blog/2013/2013-01-28-3d-logo.md
+++ b/content/blog/2013/2013-01-28-3d-logo.md
@@ -4,8 +4,8 @@ date = "2013-01-28T23:42:00"
 authors = ["Ben"]
 
 [taxonomies]
-Serie = ["Projekt"]
-Typ = ["Infrastructure"]
+Typ = ["Projekt"]
+Serie = ["Infrastructure"]
 
 [extra]
 thumbnail = "/media/blog/2013/3d-logo/thumbnail.jpg"

--- a/content/blog/2013/2013-07-14-smartphone-debug-adapter.md
+++ b/content/blog/2013/2013-07-14-smartphone-debug-adapter.md
@@ -4,8 +4,8 @@ date = "2013-07-14T23:00:00"
 authors = ["sre"]
 
 [taxonomies]
-Serie = ["Projekt"]
-Typ = ["Hardware"]
+Typ = ["Projekt"]
+Serie = ["Hardware"]
 
 [extra]
 thumbnail = "/media/blog/2013/smartphone-debug-adapter/thumbnail.jpg"

--- a/content/blog/2013/2013-07-18-lederschuhe.md
+++ b/content/blog/2013/2013-07-18-lederschuhe.md
@@ -4,8 +4,8 @@ date = "2013-07-18T10:00:00"
 authors = ["Fermate"]
 
 [taxonomies]
-Serie = ["Projekt"]
-Typ = ["Software"]
+Typ = ["Projekt"]
+Serie = ["Software"]
 
 [extra]
 thumbnail = "/media/blog/2013/lederschuhe/thumbnail.jpg"

--- a/content/blog/2013/2013-08-01-salatbaum.md
+++ b/content/blog/2013/2013-08-01-salatbaum.md
@@ -5,8 +5,8 @@ date = "2013-08-01T10:00:00"
 updated = "2024-03-24T23:42:00"
 
 [taxonomies]
-Serie = ["Projekt"]
-Typ = ["Hardware"]
+Typ = ["Projekt"]
+Serie = ["Hardware"]
 
 [extra]
 thumbnail = "/media/blog/2013/salatbaum/thumbnail.jpg"

--- a/content/blog/2013/2013-08-01-siebdruck-dings.md
+++ b/content/blog/2013/2013-08-01-siebdruck-dings.md
@@ -5,8 +5,8 @@ date = "2013-08-01T10:00:00"
 updated = "2024-03-24T23:42:00"
 
 [taxonomies]
-Serie = ["Projekt"]
-Typ = ["Hardware"]
+Typ = ["Projekt"]
+Serie = ["Hardware"]
 
 [extra]
 thumbnail = "/media/blog/2013/siebdruck-dings/thumbnail.jpg"

--- a/content/blog/2014/2014-08-15-pcb-printer.md
+++ b/content/blog/2014/2014-08-15-pcb-printer.md
@@ -4,8 +4,8 @@ date = "2014-08-15T17:00:00"
 authors = ["Hauke"]
 
 [taxonomies]
-Serie = ["Projekt"]
-Typ = ["Hardware"]
+Typ = ["Projekt"]
+Serie = ["Hardware"]
 
 [extra]
 thumbnail = "/media/blog/2014/pcb-printer/thumbnail.jpg"

--- a/content/blog/2016/2016-12-06-acs.md
+++ b/content/blog/2016/2016-12-06-acs.md
@@ -4,8 +4,8 @@ date = "2016-12-06T00:00:00"
 authors = ["sre"]
 
 [taxonomies]
-Serie = ["Projekt"]
-Typ = ["Infrastructure"]
+Typ = ["Projekt"]
+Serie = ["Infrastructure"]
 
 [extra]
 thumbnail = "/media/blog/2016/acs/hacs-thumb.svg"

--- a/content/blog/2016/2016-12-09-tiny-ws2812-controller.md
+++ b/content/blog/2016/2016-12-09-tiny-ws2812-controller.md
@@ -4,8 +4,8 @@ date = "2016-12-09T00:00:00"
 authors = ["sre"]
 
 [taxonomies]
-Serie = ["Projekt"]
-Typ = ["Hardware"]
+Typ = ["Projekt"]
+Serie = ["Hardware"]
 
 [extra]
 thumbnail = "/media/blog/2016/tiny-ws2812-controller/thumbnail.jpg"

--- a/content/blog/2016/2016-12-10-display-grabber.md
+++ b/content/blog/2016/2016-12-10-display-grabber.md
@@ -5,8 +5,8 @@ updated = "2024-03-24T23:42:00"
 authors = ["sre"]
 
 [taxonomies]
-Serie = ["Projekt"]
-Typ = ["Hardware"]
+Typ = ["Projekt"]
+Serie = ["Hardware"]
 
 [extra]
 thumbnail = "/media/blog/2016/abus-cfa1000-display-grabber/thumbnail.png"

--- a/content/blog/2016/2016-12-10-i2c-tiny-usb.md
+++ b/content/blog/2016/2016-12-10-i2c-tiny-usb.md
@@ -4,8 +4,8 @@ date = "2016-12-10T05:50:00"
 authors = ["sre"]
 
 [taxonomies]
-Serie = ["Projekt"]
-Typ = ["Hardware"]
+Typ = ["Projekt"]
+Serie = ["Hardware"]
 
 [extra]
 thumbnail = "/media/blog/2016/i2c-tiny-usb/thumbnail.png"

--- a/content/blog/2018/2018-11-09-ladekoffer.md
+++ b/content/blog/2018/2018-11-09-ladekoffer.md
@@ -4,8 +4,8 @@ date = "2018-11-09T12:15:00"
 authors = ["asc"]
 
 [taxonomies]
-Serie = ["Projekt"]
-Typ = ["Hardware"]
+Typ = ["Projekt"]
+Serie = ["Hardware"]
 
 [extra]
 thumbnail = "/media/blog/2018/ladekoffer/thumb_IMG_20181109_193018.jpg_2k.jpg"

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,6 @@
 - Add Event Calendar
     - Upcoming Events on the sidebar
     - Dedicated Calendar page
-- Make taxonomy listings more easily accessible
 
 # Potential Improvements
 

--- a/templates/blog.html
+++ b/templates/blog.html
@@ -9,6 +9,17 @@
             </h1>
         </div>
     </div>
+    <div class="row">
+        <div class="col">
+            <p>Willkommen in unserem Blog!</p>
+
+            <p>
+            Hier findest du Ankündigungen, Berichte zu Events, Einblicke in laufende Projekte und Talks.
+            Beiträge lassen sich nach <a href=/typ>Typ</a> und <a href=/serie>Serie</a> filtern, damit du schnell findest, was dich interessiert.
+            Der Blog lebt vom Mitmachen – deshalb bist du herzlich eingeladen, eigene Beiträge einzureichen.
+            </p>
+        </div>
+    </div>
     <div class="d-flex justify-content-end">
         {% if section.subsections | length > 0 %}
             <div class="d-flex flex-wrap justify-content-center">

--- a/templates/blog.html
+++ b/templates/blog.html
@@ -2,6 +2,13 @@
 {% import "macros.html" as macros %}
 
 {% block content %}
+    <div class="row">
+        <div class="col">
+            <h1>
+                {{ trans(key="blog", lang=lang) }}
+            </h1>
+        </div>
+    </div>
     <div class="d-flex justify-content-end">
         {% if section.subsections | length > 0 %}
             <div class="d-flex flex-wrap justify-content-center">


### PR DESCRIPTION
This contains three things in the blog:

- Add a "Blog" header -- same as for all the other main pages
- Add a small "welcome" sentence that explains what the blog is about and contains a helpful link to the taxonomy listings -- bit of a cheap fix, but better than nothing.
- Switches around the taxonomies for projects. Previously, we had "Infrastructure", "Software", "Hardware" as `Typ` and "Projekt" as `Serie` --> I've switched these around so the four `Typ`es are now "Ankündigung", "Event", "Talk" and "Projekt". This makes the not-so-nice-and-slightly-old project articles in the blog a little less prominent, but -- imho -- still easier to find if you're looking for them.

Preview:

<img width="1016" height="362" alt="image" src="https://github.com/user-attachments/assets/d854199b-f34e-488e-ad59-797006902907" />
