### PR TITLE
Suggestion: Show only simplified status

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -73,11 +73,7 @@ bs_color_map = [
 ]
 
 rooms = [
-    { name = "spaceOpen", title = { de = "Hackspace", en = "Hackspace" } },
-    { name = "machining", title = { de = "Zerspanung", en = "Machining" } },
-    { name = "woodworking", title = { de = "Holzwerkstatt", en = "Woodworking" } },
-    { name = "lab3dOpen", title = { de = "3D Lab", en = "3D Lab" } },
-    { name = "radstelleOpen", title = { de = "Radstelle", en = "Cycling" } },
+    { name = "spaceOpen", title = { de = "Mainframe", en = "Mainframe" } },
 ]
 
 google_cal_id = "markusframer@gmail.com"

--- a/static/js/site.js
+++ b/static/js/site.js
@@ -2,7 +2,7 @@
    status handling
 */
 
-const StatusApiUrl = "https://status.kreativitaet-trifft-technik.de/api/statusStream?spaceOpen=1&radstelleOpen=1&machining=1&woodworking=1&lab3dOpen=1";
+const StatusApiUrl = "https://status.kreativitaet-trifft-technik.de/api/statusStream?spaceOpen=1";
 
 function set_status(room, state) {
     console.info("Updating room state", room, state);
@@ -117,10 +117,6 @@ function init_status() {
     };
 
     status_source.addEventListener('spaceOpen', on_status_change);
-    status_source.addEventListener('lab3dOpen', on_status_change);
-    status_source.addEventListener('radstelleOpen', on_status_change);
-    status_source.addEventListener('machining', on_status_change);
-    status_source.addEventListener('woodworking', on_status_change);
 
     status_source.addEventListener('keepalive', function (e) {
         last_keepalive = Date.now();

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -2,7 +2,7 @@
     <div class="d-flex flex-column">
         <h3>
             <a class="ms-2" href="//status.mainframe.io">
-                Status
+                Space-Status
             </a>
         </h3>
 
@@ -10,25 +10,22 @@
             <a role="button" id="status-template"
                 class="d-flex p-0 flex-column text-decoration-none btn btn-white rounded-0 text-dark d-none border-bottom border-black"
                 href="//status.mainframe.io">
-                <div class="text-start ps-1 fw-bold lh-sm" id="status-name-template">
-                    Template:
-                </div>
                 <div class="text-end pe-1 lh-sm" id="status-text-unknown-template">
                     ???
                 </div>
-                <div class="text-end pe-1 lh-sm d-none" id="status-text-closed-template">
+                <div class="pe-1 d-none" id="status-text-closed-template">
                     {{ trans(key="closed", lang=lang) }}
                 </div>
-                <div class="text-end pe-1 lh-sm d-none" id="status-text-closing-template">
+                <div class="pe-1 d-none" id="status-text-closing-template">
                     {{ trans(key="closing", lang=lang) }}
                 </div>
-                <div class="text-end pe-1 lh-sm d-none" id="status-text-open-template">
+                <div class="pe-1 d-none" id="status-text-open-template">
                     {{ trans(key="open", lang=lang) }}
                 </div>
-                <div class="text-end pe-1 lh-sm d-none" id="status-text-member-template">
+                <div class="pe-1 d-none" id="status-text-member-template">
                     {{ trans(key="member", lang=lang) }}
                 </div>
-                <div class="text-end pe-1 lh-sm d-none" id="status-text-keyholder-template">
+                <div class="pe-1 d-none" id="status-text-keyholder-template">
                     {{ trans(key="keyholder", lang=lang) }}
                 </div>
             </a>


### PR DESCRIPTION
This removes the status of the other rooms from the main page.

Advantage is that the space looks less "closed" because most of the times the extra rooms aren't open and that the view is simpler -- especially for people who don't know the space yet.

Disadvantage is that you'd now need to go to the dedicated status page to view the status.

Old:

<img width="328" height="281" alt="image" src="https://github.com/user-attachments/assets/f605a439-9f59-4c9c-b7a2-f6fa18535439" />


New:

<img width="329" height="102" alt="image" src="https://github.com/user-attachments/assets/617199b2-f953-481b-b3c9-364e2605649a" />
